### PR TITLE
Consent Adapter Usercentrics 0.2.8-2 into Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Core SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Core SDK version within that major version.
 
+### Version 0.2.8-2 *(2023-10-19)*
+- Updated Unity dependency to Chartboost Core Unity SDK `0.3.0`.
+- Updated native Android dependency to use `0.2.8.1.3`.
+- Updated native iOS dependency to use `0.2.8.0.1`.
+
 ### Version 0.2.8-1 *(2023-09-07)*
+- Updated Unity dependency to Chartboost Core Unity SDK `0.2.0`.
 - Updated native Android dependency to use `0.2.8.1.2`.
 
 ### Version 0.2.8-0

--- a/Editor/ChartboostCoreConsentUsercentricDependencies.xml
+++ b/Editor/ChartboostCoreConsentUsercentricDependencies.xml
@@ -2,11 +2,11 @@
 <dependencies>
     <androidPackages>
         <!-- Usercentrics Dependency -->
-        <androidPackage spec="com.chartboost:chartboost-core-consent-adapter-usercentrics:0.2.8.1.2@aar"/>
+        <androidPackage spec="com.chartboost:chartboost-core-consent-adapter-usercentrics:0.2.8.1.3@aar"/>
         <androidPackage spec="com.usercentrics.sdk:usercentrics-ui:2.8.1"/>
     </androidPackages>
     <iosPods>
         <!-- Usercentrics Podspec -->
-        <iosPod name="ChartboostCoreConsentAdapterUsercentrics" version="~> 0.2.8.0" addToAllTargets="true"/>
+        <iosPod name="ChartboostCoreConsentAdapterUsercentrics" version="0.2.8.0.1" addToAllTargets="true"/>
     </iosPods>
 </dependencies>

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "com.chartboost.core.consent.usercentrics",
   "displayName": "Chartboost Core Consent Usercentrics",
-  "version": "0.2.8-1",
+  "version": "0.2.8-2",
   "unity": "2020.3",
   "dependencies": {
     "com.unity.nuget.newtonsoft-json": "3.2.1",
-    "com.chartboost.core": "0.2.0"
+    "com.chartboost.core": "0.3.0"
   },
   "keywords": [],
   "license": "",


### PR DESCRIPTION
# Title
Consent Adapter Usercentrics 0.2.8-2

# Description

Consent Adapter Usercentrics 0.2.8-2, this version is only compatible with Chartboost Core Unity SDK 0.3.0. 
## Type of change

- [x] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Refactor / Maintenance (refactoring code to be cleaner/easier to maintain)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
