### PR TITLE
Consent Adapter Usercentrics 0.2.8-3 into Develop 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Core SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Core SDK version within that major version.
 
+### Version 0.2.8-3 *(2023-10-19)*
+- Updated Unity dependency to Chartboost Core Unity SDK `0.3.1`.
+
 ### Version 0.2.8-2 *(2023-10-19)*
 - Updated Unity dependency to Chartboost Core Unity SDK `0.3.0`.
 - Updated native Android dependency to use `0.2.8.1.3`.

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "com.chartboost.core.consent.usercentrics",
   "displayName": "Chartboost Core Consent Usercentrics",
-  "version": "0.2.8-2",
+  "version": "0.2.8-3",
   "unity": "2020.3",
   "dependencies": {
     "com.unity.nuget.newtonsoft-json": "3.2.1",
-    "com.chartboost.core": "0.3.0"
+    "com.chartboost.core": "0.3.1"
   },
   "keywords": [],
   "license": "",


### PR DESCRIPTION
# Title
Consent Adapter Usercentrics 0.2.8-3

# Description

Consent Adapter Usercentrics 0.2.8-3, this version is only compatible with Chartboost Core Unity SDK 0.3.1. The npm package for Chartboost Core Unity SDK 0.3.0 had invalid dependencies.

## Type of change

- [x] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Refactor / Maintenance (refactoring code to be cleaner/easier to maintain)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
